### PR TITLE
Add option to skip benchmarks

### DIFF
--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDC.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDC.kt
@@ -29,12 +29,14 @@ class JacocoDC(
     oneCoverageForParameterizedBenchmarks: Boolean = true,
     inclusion: CoverageInclusions = IncludeAll,
     private val coverageUnitType: CoverageUnitType,
-    timeOut: Duration = Duration.ofMinutes(10)
-) : AbstractDynamicCoverage(
+    timeOut: Duration = Duration.ofMinutes(10),
+    skipBenchmarksFile: String
+    ) : AbstractDynamicCoverage(
     benchmarkFinder = benchmarkFinder,
     javaSettings = javaSettings,
     oneCoverageForParameterizedBenchmarks = oneCoverageForParameterizedBenchmarks,
     timeOut = timeOut,
+    skipBenchmarksFile = skipBenchmarksFile,
 ), CoverageExecutor {
 
     private val inclusionsString = inclusions(inclusion)

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/javacallgraph/JavaCallgraphDC.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/javacallgraph/JavaCallgraphDC.kt
@@ -27,12 +27,14 @@ class JavaCallgraphDC(
     oneCovForParameterizedBenchmarks: Boolean = true,
     inclusion: CoverageInclusions = IncludeAll,
     timeOut: Duration = Duration.ofMinutes(10),
-) : AbstractDynamicCoverage(
+    skipBenchmarksFile: String,
+    ) : AbstractDynamicCoverage(
     benchmarkFinder = benchmarkFinder,
     javaSettings = javaSettings,
     oneCoverageForParameterizedBenchmarks = oneCovForParameterizedBenchmarks,
     timeOut = timeOut,
-), CoverageExecutor {
+    skipBenchmarksFile = skipBenchmarksFile,
+    ), CoverageExecutor {
 
     private val inclusionsString: String = inclusions(inclusion)
 

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandBencher.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandBencher.kt
@@ -43,6 +43,12 @@ internal class CommandMain : Runnable {
     var out: OutputStream = System.out
 
     @CommandLine.Option(
+        names = ["-skip", "--skip-benchmarks"],
+        description = ["ignore benchmarks contained in the file"],
+    )
+    var skipBenchmarksFile: String = ""
+
+    @CommandLine.Option(
             names = ["-pf", "--package-prefix", "--package-prefixes"],
             description = ["project package prefix"],
             converter = [PrefixesConverter::class]

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandDC.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandDC.kt
@@ -65,6 +65,7 @@ internal class CommandDC : Callable<CommandExecutor> {
                 oneCoverageForParameterizedBenchmarks = !multipleCovsForParameterizedBenchmark,
                 coverageUnitType = cut.coverageUnitType,
                 inclusion = cov.inclusions,
+                skipBenchmarksFile = parent.skipBenchmarksFile
             ),
             jar = jar.toPath(),
         )


### PR DESCRIPTION
Works only for benchmarks without parameters

Usage example:
`
java -jar /path/to/bencher.jar -p jctools -pf org.jctools -skip /path/to/exclude.txt -out out.txt dc -f /path/to/jctools.jar -inc "org.jctools" -covpb -cut ALL --java-home="/path/to/java/home"
`

exclude.txt example:
```
org.jctools.queues.unpadded.BaseLinkedUnpaddedQueue_ESTest._Benchmark.benchmark_test18
org.jctools.queues.MpscLinkedQueue_ESTest._Benchmark.benchmark_test01
```