### PR TITLE
Add option to skip benchmarks

### DIFF
--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/AbstractDynamicCoverage.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/AbstractDynamicCoverage.kt
@@ -27,16 +27,23 @@ abstract class AbstractDynamicCoverage(
         ) : CoverageExecutor {
 
     private val env: Map<String, String> = mapOfNotNull(javaSettings.homePair())
-    private var skipBenchmarks: List<String> = listOf()
+    private var benchmarksToSkip: List<String> = listOf()
 
     override fun get(jar: Path): Either<String, Coverages> {
         val ebs = benchmarkFinder.all()
+        benchmarksToSkip = getBenchmarksToSkip()
+
+        log.info("Skip benchmarks: ${benchmarksToSkip}")
+
         val bs: List<Benchmark> = ebs.getOrElse {
             return Either.Left(it)
+        }.filter { b ->
+            // Check if the benchmark matches any line from the file
+            val searchString = (b.clazz.replace("$", ".") + "." +  b.name).trim()
+            !benchmarksToSkip.any { it.contains(searchString)  }
         }
-        skipBenchmarks = getBenchmarksToSkip()
 
-        val total = bs.size - skipBenchmarks.size
+        val total = bs.size
         log.info("start generating coverages")
         val startCoverages = LocalDateTime.now()
 
@@ -112,29 +119,21 @@ abstract class AbstractDynamicCoverage(
         log.info(cs)
         log.debug("Param bench $b: ${i + 1}/$total; '$cs'")
 
-        val searchString = (b.clazz.replace("$", ".") + "." +  b.name).trim()
-
-        if(skipBenchmarks.any { it.contains(searchString) }) {
-            return null
-        } else {
-            val l = logTimesParam(b, i, total, "coverage for parameterized benchmark")
-            val ers = exec(cs, env, jar, tmpDir, b)
-            return try {
-                ers
-                    .mapLeft {
-                        log.error("Could not retrieve DC for $b with '$cs': $it")
-                        null
-                    }
-                    .map {
-                        Pair(b, it)
-                    }
-                    .getOrNull()
-            } finally {
-                l()
-            }
+        val l = logTimesParam(b, i, total, "coverage for parameterized benchmark")
+        val ers = exec(cs, env, jar, tmpDir, b)
+        return try {
+            ers
+                .mapLeft {
+                    log.error("Could not retrieve DC for $b with '$cs': $it")
+                    null
+                }
+                .map {
+                    Pair(b, it)
+                }
+                .getOrNull()
+        } finally {
+            l()
         }
-
-
     }
 
     private fun coverageParam(jar: Path, total: Int, tmpDir: File, bs: List<Benchmark>): List<Pair<Benchmark, Coverage>> =
@@ -270,13 +269,13 @@ abstract class AbstractDynamicCoverage(
 
     private fun benchName(b: Benchmark): String = "${b.clazz.replace("$", ".")}.${b.name}"
 
-    private fun getBenchmarksToSkip(): List<String> {
+    public fun getBenchmarksToSkip(): List<String> {
         val benchmarks: MutableList<String> = mutableListOf()
         val file = File(skipBenchmarksFile)
 
         if (file.exists()) {
             try {
-                benchmarks.addAll(file.readLines().map { it.trim() })
+                benchmarks.addAll(file.readLines().map { it.replace("$", ".").trim() })
             } catch (e: Exception) {
                 println("Error reading the file: ${e.message}")
             }

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDC.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDC.kt
@@ -29,12 +29,14 @@ class JacocoDC(
     oneCoverageForParameterizedBenchmarks: Boolean = true,
     inclusion: CoverageInclusions = IncludeAll,
     private val coverageUnitType: CoverageUnitType,
-    timeOut: Duration = Duration.ofMinutes(10)
-) : AbstractDynamicCoverage(
+    timeOut: Duration = Duration.ofMinutes(10),
+    skipBenchmarksFile: String
+    ) : AbstractDynamicCoverage(
     benchmarkFinder = benchmarkFinder,
     javaSettings = javaSettings,
     oneCoverageForParameterizedBenchmarks = oneCoverageForParameterizedBenchmarks,
     timeOut = timeOut,
+    skipBenchmarksFile = skipBenchmarksFile,
 ), CoverageExecutor {
 
     private val inclusionsString = inclusions(inclusion)

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/javacallgraph/JavaCallgraphDC.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/javacallgraph/JavaCallgraphDC.kt
@@ -27,12 +27,14 @@ class JavaCallgraphDC(
     oneCovForParameterizedBenchmarks: Boolean = true,
     inclusion: CoverageInclusions = IncludeAll,
     timeOut: Duration = Duration.ofMinutes(10),
-) : AbstractDynamicCoverage(
+    skipBenchmarksFile: String,
+    ) : AbstractDynamicCoverage(
     benchmarkFinder = benchmarkFinder,
     javaSettings = javaSettings,
     oneCoverageForParameterizedBenchmarks = oneCovForParameterizedBenchmarks,
     timeOut = timeOut,
-), CoverageExecutor {
+    skipBenchmarksFile = skipBenchmarksFile,
+    ), CoverageExecutor {
 
     private val inclusionsString: String = inclusions(inclusion)
 

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandBencher.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandBencher.kt
@@ -43,6 +43,12 @@ internal class CommandMain : Runnable {
     var out: OutputStream = System.out
 
     @CommandLine.Option(
+        names = ["-skip", "--skip-benchmarks"],
+        description = ["ignore benchmarks contained in the file"],
+    )
+    var skipBenchmarksFile: String = ""
+
+    @CommandLine.Option(
             names = ["-pf", "--package-prefix", "--package-prefixes"],
             description = ["project package prefix"],
             converter = [PrefixesConverter::class]

--- a/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandDC.kt
+++ b/src/main/kotlin/ch/uzh/ifi/seal/bencher/cli/CommandDC.kt
@@ -65,6 +65,7 @@ internal class CommandDC : Callable<CommandExecutor> {
                 oneCoverageForParameterizedBenchmarks = !multipleCovsForParameterizedBenchmark,
                 coverageUnitType = cut.coverageUnitType,
                 inclusion = cov.inclusions,
+                skipBenchmarksFile = parent.skipBenchmarksFile
             ),
             jar = jar.toPath(),
         )

--- a/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDCAllTest.kt
+++ b/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDCAllTest.kt
@@ -25,6 +25,7 @@ class JacocoDCAllTest {
             oneCoverageForParameterizedBenchmarks = false,
             coverageUnitType = CoverageUnitType.ALL,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -48,6 +49,7 @@ class JacocoDCAllTest {
             oneCoverageForParameterizedBenchmarks = false,
             coverageUnitType = CoverageUnitType.ALL,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -71,6 +73,7 @@ class JacocoDCAllTest {
             oneCoverageForParameterizedBenchmarks = true,
             coverageUnitType = CoverageUnitType.ALL,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -94,6 +97,7 @@ class JacocoDCAllTest {
             oneCoverageForParameterizedBenchmarks = true,
             coverageUnitType = CoverageUnitType.ALL,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -105,5 +109,31 @@ class JacocoDCAllTest {
         DCTestHelper.coveragesNonParamV2.coverages.forEach { (m, c) ->
             DCTestHelper.checkCovResult(cov, m, c.all().map { it as Covered })
         }
+    }
+
+    @Test
+    fun testSkipBenchmarks() {
+        val jar = JarTestHelper.jar4BenchsJmh121v2.fileResource()
+
+        val cove = JacocoDC(
+            benchmarkFinder = AsmBenchFinder(
+                jar = jar,
+                pkgPrefixes = setOf("org.sample")
+            ),
+            javaSettings = javaSettings,
+            oneCoverageForParameterizedBenchmarks = true,
+            coverageUnitType = CoverageUnitType.ALL,
+            inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "src/test/resources/benchmarks_to_skip.txt"
+        )
+
+        val cov = cove.get(jar.toPath()).getOrElse {
+            Assertions.fail<String>("Could not retrieve coverages: $it")
+            return
+        }
+
+        val toSkip: List<String> = cove.getBenchmarksToSkip()
+        Assertions.assertEquals(3, toSkip.size)
+        Assertions.assertEquals(10, cov.coverages.size)
     }
 }

--- a/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDCLineTest.kt
+++ b/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDCLineTest.kt
@@ -25,6 +25,7 @@ class JacocoDCLineTest {
             oneCoverageForParameterizedBenchmarks = false,
             coverageUnitType = CoverageUnitType.LINE,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -48,6 +49,7 @@ class JacocoDCLineTest {
             oneCoverageForParameterizedBenchmarks = false,
             coverageUnitType = CoverageUnitType.LINE,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -71,6 +73,7 @@ class JacocoDCLineTest {
             oneCoverageForParameterizedBenchmarks = true,
             coverageUnitType = CoverageUnitType.LINE,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -94,6 +97,7 @@ class JacocoDCLineTest {
             oneCoverageForParameterizedBenchmarks = true,
             coverageUnitType = CoverageUnitType.LINE,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {

--- a/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDCMethodTest.kt
+++ b/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/jacoco/JacocoDCMethodTest.kt
@@ -25,6 +25,7 @@ class JacocoDCMethodTest {
             oneCoverageForParameterizedBenchmarks = false,
             coverageUnitType = CoverageUnitType.METHOD,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -48,6 +49,7 @@ class JacocoDCMethodTest {
             oneCoverageForParameterizedBenchmarks = false,
             coverageUnitType = CoverageUnitType.METHOD,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -71,6 +73,7 @@ class JacocoDCMethodTest {
             oneCoverageForParameterizedBenchmarks = true,
             coverageUnitType = CoverageUnitType.METHOD,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -94,6 +97,7 @@ class JacocoDCMethodTest {
             oneCoverageForParameterizedBenchmarks = true,
             coverageUnitType = CoverageUnitType.METHOD,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {

--- a/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/javacallgraph/JavaCallgraphDCTest.kt
+++ b/src/test/kotlin/ch/uzh/ifi/seal/bencher/analysis/coverage/dyn/javacallgraph/JavaCallgraphDCTest.kt
@@ -25,6 +25,7 @@ class JavaCallgraphDCTest {
             javaSettings = javaSettings,
             oneCovForParameterizedBenchmarks = false,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -65,6 +66,7 @@ class JavaCallgraphDCTest {
             javaSettings = javaSettings,
             oneCovForParameterizedBenchmarks = false,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -87,6 +89,7 @@ class JavaCallgraphDCTest {
             javaSettings = javaSettings,
             oneCovForParameterizedBenchmarks = true,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {
@@ -109,6 +112,7 @@ class JavaCallgraphDCTest {
             javaSettings = javaSettings,
             oneCovForParameterizedBenchmarks = true,
             inclusion = IncludeOnly(setOf("org.sample")),
+            skipBenchmarksFile = "example/file.txt"
         )
 
         val cov = cove.get(jar.toPath()).getOrElse {

--- a/src/test/resources/benchmarks_to_skip.txt
+++ b/src/test/resources/benchmarks_to_skip.txt
@@ -1,0 +1,3 @@
+org.sample.BenchNonParameterized.bench2
+org.sample.BenchsWithGroup.bench3
+org.sample.NestedBenchmark.Bench1.bench12


### PR DESCRIPTION
Works only for benchmarks without parameters. Any `$` in the benchmark name must be replaced by `.` in the provided file.

Usage example:
`
java -jar /path/to/bencher.jar -p jctools -pf org.jctools -skip /path/to/exclude.txt -out out.txt dc -f /path/to/jctools.jar -inc "org.jctools" -covpb -cut ALL --java-home="/path/to/java/home"
`

exclude.txt example:
```
org.jctools.queues.unpadded.BaseLinkedUnpaddedQueue_ESTest._Benchmark.benchmark_test18
org.jctools.queues.MpscLinkedQueue_ESTest._Benchmark.benchmark_test01
```